### PR TITLE
(Very) minor change - variable consistency

### DIFF
--- a/notebooks/4_Utils/save_restore_model.ipynb
+++ b/notebooks/4_Utils/save_restore_model.ipynb
@@ -207,7 +207,7 @@
     "\n",
     "    # Restore model weights from previously saved model\n",
     "    load_path = saver.restore(sess, model_path)\n",
-    "    print \"Model restored from file: %s\" % save_path\n",
+    "    print \"Model restored from file: %s\" % load_path\n",
     "\n",
     "    # Resume training\n",
     "    for epoch in range(7):\n",


### PR DESCRIPTION
Uses otherwise unused variable load_path.
Avoids possibility of printing wrong info if something happens to save_path in between the two blocks' execution.