### PR TITLE
Fix: Comment explanation wrong

### DIFF
--- a/examples/3_NeuralNetworks/dynamic_rnn.py
+++ b/examples/3_NeuralNetworks/dynamic_rnn.py
@@ -143,7 +143,7 @@ def dynamicRNN(x, seqlen, weights, biases):
 
     # Hack to build the indexing and retrieve the right output.
     batch_size = tf.shape(outputs)[0]
-    # Start indices for each sample
+    # End indices for each sample
     index = tf.range(0, batch_size) * seq_max_len + (seqlen - 1)
     # Indexing
     outputs = tf.gather(tf.reshape(outputs, [-1, n_hidden]), index)


### PR DESCRIPTION
The comment for this line of code

index = tf.range(0, batch_size) * seq_max_len + (seqlen - 1)

was written: Start indices for each sample
when it actually is: End indices for each sample

(Since it is a tutorial file, so this comment is important for understanding)