### PR TITLE
replaced 'tf.mul' (deprecated) by 'tf.multiply'

### DIFF
--- a/examples/1_Introduction/basic_operations.py
+++ b/examples/1_Introduction/basic_operations.py
@@ -30,7 +30,7 @@ b = tf.placeholder(tf.int16)
 
 # Define some operations
 add = tf.add(a, b)
-mul = tf.mul(a, b)
+mul = tf.multiply(a, b)
 
 # Launch the default graph.
 with tf.Session() as sess:

--- a/examples/2_BasicModels/linear_regression.py
+++ b/examples/2_BasicModels/linear_regression.py
@@ -33,7 +33,7 @@ W = tf.Variable(rng.randn(), name="weight")
 b = tf.Variable(rng.randn(), name="bias")
 
 # Construct a linear model
-pred = tf.add(tf.mul(X, W), b)
+pred = tf.add(tf.multiply(X, W), b)
 
 # Mean squared error
 cost = tf.reduce_sum(tf.pow(pred-Y, 2))/(2*n_samples)

--- a/notebooks/1_Introduction/basic_operations.ipynb
+++ b/notebooks/1_Introduction/basic_operations.ipynb
@@ -90,7 +90,7 @@
    "source": [
     "# Define some operations\n",
     "add = tf.add(a, b)\n",
-    "mul = tf.mul(a, b)"
+    "mul = tf.multiply(a, b)"
    ]
   },
   {

--- a/notebooks/2_BasicModels/linear_regression.ipynb
+++ b/notebooks/2_BasicModels/linear_regression.ipynb
@@ -84,7 +84,7 @@
    "outputs": [],
    "source": [
     "# Construct a linear model\n",
-    "pred = tf.add(tf.mul(X, W), b)"
+    "pred = tf.add(tf.multiply(X, W), b)"
    ]
   },
   {


### PR DESCRIPTION
This PR is just a few replacements `tf.mul` to `tf.multiply`. I also checked for occurrences of `tf.sub` and `tf.neg`, which weren't there.