### PR TITLE
Mul operation has been deprecated in Tensorflow 1.0.0

### DIFF
--- a/examples/1_Introduction/basic_operations.py
+++ b/examples/1_Introduction/basic_operations.py
@@ -30,7 +30,7 @@ b = tf.placeholder(tf.int16)
 
 # Define some operations
 add = tf.add(a, b)
-mul = tf.mul(a, b)
+mul = tf.muliply(a, b)
 
 # Launch the default graph.
 with tf.Session() as sess:


### PR DESCRIPTION
`tensorflow.mul` has been deprecated as part of Tensorflow 1.0.0. It's better to use `tensorflow.multiply` instead.