### PR TITLE
Fixed a bug with a function name spelling

### DIFF
--- a/examples/1_Introduction/basic_operations.py
+++ b/examples/1_Introduction/basic_operations.py
@@ -30,7 +30,7 @@ b = tf.placeholder(tf.int16)
 
 # Define some operations
 add = tf.add(a, b)
-mul = tf.mul(a, b)
+mul = tf.multiply(a, b)
 
 # Launch the default graph.
 with tf.Session() as sess:


### PR DESCRIPTION
It seems that the spelling of the multiply function name is wrong.