### PR TITLE
tf.mul -> tf.multiply

### DIFF
--- a/notebooks/2_BasicModels/linear_regression.ipynb
+++ b/notebooks/2_BasicModels/linear_regression.ipynb
@@ -84,7 +84,7 @@
    "outputs": [],
    "source": [
     "# Construct a linear model\n",
-    "pred = tf.add(tf.mul(X, W), b)"
+    "pred = tf.add(tf.multiply(X, W), b)"
    ]
   },
   {


### PR DESCRIPTION
Currently the linear regression notebook yields an error because of usage of the deprecated `tf.mut` function.

```python
AttributeError: 'module' object has no attribute 'mul'
```

This PR fixes that. 