### PR TITLE
Sigmoid -> ReLU

### DIFF
--- a/examples/3_NeuralNetworks/autoencoder.py
+++ b/examples/3_NeuralNetworks/autoencoder.py
@@ -41,31 +41,31 @@ weights = {
     'decoder_h2': tf.Variable(tf.random_normal([n_hidden_1, n_input])),
 }
 biases = {
-    'encoder_b1': tf.Variable(tf.random_normal([n_hidden_1])),
-    'encoder_b2': tf.Variable(tf.random_normal([n_hidden_2])),
-    'decoder_b1': tf.Variable(tf.random_normal([n_hidden_1])),
-    'decoder_b2': tf.Variable(tf.random_normal([n_input])),
+    'encoder_b1': tf.Variable(tf.constant(0.1, shape=[n_hidden_1])),
+    'encoder_b2': tf.Variable(tf.constant(0.1, shape=[n_hidden_2])),
+    'decoder_b1': tf.Variable(tf.constant(0.1, shape=[n_hidden_1])),
+    'decoder_b2': tf.Variable(tf.constant(0.1, shape=[n_input])),
 }
 
 
 # Building the encoder
 def encoder(x):
-    # Encoder Hidden layer with sigmoid activation #1
-    layer_1 = tf.nn.sigmoid(tf.add(tf.matmul(x, weights['encoder_h1']),
+    # Encoder Hidden layer with relu activation #1
+    layer_1 = tf.nn.relu(tf.add(tf.matmul(x, weights['encoder_h1']),
                                    biases['encoder_b1']))
-    # Decoder Hidden layer with sigmoid activation #2
-    layer_2 = tf.nn.sigmoid(tf.add(tf.matmul(layer_1, weights['encoder_h2']),
+    # Decoder Hidden layer with relu activation #2
+    layer_2 = tf.nn.relu(tf.add(tf.matmul(layer_1, weights['encoder_h2']),
                                    biases['encoder_b2']))
     return layer_2
 
 
 # Building the decoder
 def decoder(x):
-    # Encoder Hidden layer with sigmoid activation #1
-    layer_1 = tf.nn.sigmoid(tf.add(tf.matmul(x, weights['decoder_h1']),
+    # Encoder Hidden layer with relu activation #1
+    layer_1 = tf.nn.relu(tf.add(tf.matmul(x, weights['decoder_h1']),
                                    biases['decoder_b1']))
-    # Decoder Hidden layer with sigmoid activation #2
-    layer_2 = tf.nn.sigmoid(tf.add(tf.matmul(layer_1, weights['decoder_h2']),
+    # Decoder Hidden layer with relu activation #2
+    layer_2 = tf.nn.relu(tf.add(tf.matmul(layer_1, weights['decoder_h2']),
                                    biases['decoder_b2']))
     return layer_2
 


### PR DESCRIPTION
Best practice to use ReLU – initialized with small positive weights – instead of sigmoid, because of the vanishing gradient problem.