### PR TITLE
A print function miss brackets

### DIFF
--- a/notebooks/4_Utils/tensorboard_basic.ipynb
+++ b/notebooks/4_Utils/tensorboard_basic.ipynb
@@ -161,7 +161,7 @@
     "            avg_cost += c / total_batch\n",
     "        # Display logs per epoch step\n",
     "        if (epoch+1) % display_epoch == 0:\n",
-    "            print \"Epoch:\", '%04d' % (epoch+1), \"cost=\", \"{:.9f}\".format(avg_cost)\n",
+    "            print(\"Epoch:\", '%04d' % (epoch+1), \"cost=\", \"{:.9f}\".format(avg_cost))\n",
     "\n",
     "    print(\"Optimization Finished!\")\n",
     "\n",


### PR DESCRIPTION
```python
# Display logs per epoch step
        if (epoch+1) % display_epoch == 0:
            print("Epoch:", '%04d' % (epoch+1), "cost=", "{:.9f}".format(avg_cost))
```