### PR TITLE
Gan paper fix

### DIFF
--- a/notebooks/3_NeuralNetworks/dcgan.ipynb
+++ b/notebooks/3_NeuralNetworks/dcgan.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "References:\n",
     "- [Unsupervised representation learning with deep convolutional generative adversarial networks](https://arxiv.org/pdf/1511.06434). A Radford, L Metz, S Chintala, 2016.\n",
-    "- [Understanding the difficulty of training deep feedforward neural networks](www.cs.cmu.edu/~bhiksha/courses/deeplearning/Fall.../AISTATS2010_Glorot.pdf). X Glorot, Y Bengio. Aistats 9, 249-256\n",
+    "- [Understanding the difficulty of training deep feedforward neural networks](http://proceedings.mlr.press/v9/glorot10a.html). X Glorot, Y Bengio. Aistats 9, 249-256\n",
     "- [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/abs/1502.03167). Sergey Ioffe, Christian Szegedy. 2015.\n",
     "\n",
     "## MNIST Dataset Overview\n",

--- a/notebooks/3_NeuralNetworks/gan.ipynb
+++ b/notebooks/3_NeuralNetworks/gan.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "References:\n",
     "- [Generative adversarial nets](https://arxiv.org/pdf/1406.2661.pdf). I Goodfellow, J Pouget-Abadie, M Mirza, B Xu, D Warde-Farley, S Ozair, Y. Bengio. Advances in neural information processing systems, 2672-2680.\n",
-    "- [Understanding the difficulty of training deep feedforward neural networks](www.cs.cmu.edu/~bhiksha/courses/deeplearning/Fall.../AISTATS2010_Glorot.pdf). X Glorot, Y Bengio. Aistats 9, 249-256\n",
+    "- [Understanding the difficulty of training deep feedforward neural networks](http://proceedings.mlr.press/v9/glorot10a.html). X Glorot, Y Bengio. Aistats 9, 249-256\n",
     "\n",
     "Other tutorials:\n",
     "- [Generative Adversarial Networks Explained](http://kvfrans.com/generative-adversial-networks-explained/). Kevin Frans.\n",


### PR DESCRIPTION
Fix the "Xavier Glorot init" paper URL in GAN and DCGAN. The original URL gives a 404, and it was also mistakenly made as relative URL