### PR TITLE
Create Dataset with placeholders

### DIFF
--- a/examples/5_DataManagement/tensorflow_dataset_api.py
+++ b/examples/5_DataManagement/tensorflow_dataset_api.py
@@ -33,7 +33,7 @@ sess = tf.Session()
 _data = tf.placeholder(tf.float32, [None, n_input])
 _labels = tf.placeholder(tf.float32, [None, n_classes])
 # Create a dataset from the images and the labels
-dataset = tf.contrib.data.Dataset.from_tensor_slices((_data, _labels))
+dataset = tf.data.Dataset.from_tensor_slices((_data, _labels))
 # Create batches of data
 dataset = dataset.batch(batch_size)
 # Create an iterator, to go over the dataset

--- a/examples/5_DataManagement/tensorflow_dataset_api.py
+++ b/examples/5_DataManagement/tensorflow_dataset_api.py
@@ -28,17 +28,16 @@ dropout = 0.75 # Dropout, probability to keep units
 
 sess = tf.Session()
 
-# Create a dataset tensor from the images and the labels
-dataset = tf.contrib.data.Dataset.from_tensor_slices(
-    (mnist.train.images, mnist.train.labels))
-# Create batches of data
-dataset = dataset.batch(batch_size)
-# Create an iterator, to go over the dataset
-iterator = dataset.make_initializable_iterator()
 # It is better to use 2 placeholders, to avoid to load all data into memory,
 # and avoid the 2Gb restriction length of a tensor.
 _data = tf.placeholder(tf.float32, [None, n_input])
 _labels = tf.placeholder(tf.float32, [None, n_classes])
+# Create a dataset from the images and the labels
+dataset = tf.contrib.data.Dataset.from_tensor_slices((_data, _labels))
+# Create batches of data
+dataset = dataset.batch(batch_size)
+# Create an iterator, to go over the dataset
+iterator = dataset.make_initializable_iterator()
 # Initialize the iterator
 sess.run(iterator.initializer, feed_dict={_data: mnist.train.images,
                                           _labels: mnist.train.labels})


### PR DESCRIPTION
This PR creates the dataset with the `_data` and `_labels` placeholders. So far, the dataset has not used these, as it was still initialized directly with the MNIST numpy arrays. Now, it avoids the 2GB restriction mentioned in the code.

Also, this PR uses `tf.data.Dataset` instead of the deprecated `tf.contrib.data.Dataset`.

Testing done: the training converges with the same speed as before.