### PR TITLE
deprecated function => nn.softmax_cross_entropy_with_logits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/*
 checkpoint
 htmlcov
 mnist
+.idea/

--- a/examples/3_NeuralNetworks/bidirectional_rnn.py
+++ b/examples/3_NeuralNetworks/bidirectional_rnn.py
@@ -84,7 +84,7 @@ logits = BiRNN(X, weights, biases)
 prediction = tf.nn.softmax(logits)
 
 # Define loss and optimizer
-loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
+loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits_v2(
     logits=logits, labels=Y))
 optimizer = tf.train.GradientDescentOptimizer(learning_rate=learning_rate)
 train_op = optimizer.minimize(loss_op)

--- a/examples/3_NeuralNetworks/convolutional_network_raw.py
+++ b/examples/3_NeuralNetworks/convolutional_network_raw.py
@@ -100,7 +100,7 @@ logits = conv_net(X, weights, biases, keep_prob)
 prediction = tf.nn.softmax(logits)
 
 # Define loss and optimizer
-loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
+loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits_v2(
     logits=logits, labels=Y))
 optimizer = tf.train.AdamOptimizer(learning_rate=learning_rate)
 train_op = optimizer.minimize(loss_op)

--- a/examples/3_NeuralNetworks/dynamic_rnn.py
+++ b/examples/3_NeuralNetworks/dynamic_rnn.py
@@ -153,7 +153,7 @@ def dynamicRNN(x, seqlen, weights, biases):
 pred = dynamicRNN(x, seqlen, weights, biases)
 
 # Define loss and optimizer
-cost = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits=pred, labels=y))
+cost = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits_v2(logits=pred, labels=y))
 optimizer = tf.train.GradientDescentOptimizer(learning_rate=learning_rate).minimize(cost)
 
 # Evaluate model

--- a/examples/3_NeuralNetworks/multilayer_perceptron.py
+++ b/examples/3_NeuralNetworks/multilayer_perceptron.py
@@ -69,7 +69,7 @@ def multilayer_perceptron(x):
 logits = multilayer_perceptron(X)
 
 # Define loss and optimizer
-loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
+loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits_v2(
     logits=logits, labels=Y))
 optimizer = tf.train.AdamOptimizer(learning_rate=learning_rate)
 train_op = optimizer.minimize(loss_op)

--- a/examples/3_NeuralNetworks/neural_network_raw.py
+++ b/examples/3_NeuralNetworks/neural_network_raw.py
@@ -63,7 +63,7 @@ logits = neural_net(X)
 prediction = tf.nn.softmax(logits)
 
 # Define loss and optimizer
-loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
+loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits_v2(
     logits=logits, labels=Y))
 optimizer = tf.train.AdamOptimizer(learning_rate=learning_rate)
 train_op = optimizer.minimize(loss_op)

--- a/examples/3_NeuralNetworks/recurrent_network.py
+++ b/examples/3_NeuralNetworks/recurrent_network.py
@@ -73,7 +73,7 @@ logits = RNN(X, weights, biases)
 prediction = tf.nn.softmax(logits)
 
 # Define loss and optimizer
-loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
+loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits_v2(
     logits=logits, labels=Y))
 optimizer = tf.train.GradientDescentOptimizer(learning_rate=learning_rate)
 train_op = optimizer.minimize(loss_op)

--- a/examples/4_Utils/save_restore_model.py
+++ b/examples/4_Utils/save_restore_model.py
@@ -60,7 +60,7 @@ biases = {
 pred = multilayer_perceptron(x, weights, biases)
 
 # Define loss and optimizer
-cost = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits=pred, labels=y))
+cost = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits_v2(logits=pred, labels=y))
 optimizer = tf.train.AdamOptimizer(learning_rate=learning_rate).minimize(cost)
 
 # Initialize the variables (i.e. assign their default value)

--- a/examples/4_Utils/tensorboard_advanced.py
+++ b/examples/4_Utils/tensorboard_advanced.py
@@ -71,7 +71,7 @@ with tf.name_scope('Model'):
 
 with tf.name_scope('Loss'):
     # Softmax Cross entropy (cost function)
-    loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits=pred, labels=y))
+    loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits_v2(logits=pred, labels=y))
 
 with tf.name_scope('SGD'):
     # Gradient Descent

--- a/examples/5_DataManagement/tensorflow_dataset_api.py
+++ b/examples/5_DataManagement/tensorflow_dataset_api.py
@@ -98,7 +98,7 @@ logits_train = conv_net(X, n_classes, dropout, reuse=False, is_training=True)
 logits_test = conv_net(X, n_classes, dropout, reuse=True, is_training=False)
 
 # Define loss and optimizer (with train logits, for dropout to take effect)
-loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
+loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits_v2(
     logits=logits_train, labels=Y))
 optimizer = tf.train.AdamOptimizer(learning_rate=learning_rate)
 train_op = optimizer.minimize(loss_op)

--- a/examples/6_MultiGPU/multigpu_cnn.py
+++ b/examples/6_MultiGPU/multigpu_cnn.py
@@ -148,7 +148,7 @@ with tf.device('/cpu:0'):
                                    reuse=True, is_training=False)
 
             # Define loss and optimizer (with train logits, for dropout to take effect)
-            loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
+            loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits_v2(
                 logits=logits_train, labels=_y))
             optimizer = tf.train.AdamOptimizer(learning_rate=learning_rate)
             grads = optimizer.compute_gradients(loss_op)


### PR DESCRIPTION
Hi
The nn.softmax_cross_entropy_with_logits function has been deprecated and warns in console, so i replaced it with the recommended one nn.softmax_cross_entropy_with_logits_v2.
I also added .idea/ directory to .gitignore for pycharm users.
Regards