### PR TITLE
Define xrange() in Python 3

### DIFF
--- a/examples/2_BasicModels/word2vec.py
+++ b/examples/2_BasicModels/word2vec.py
@@ -24,6 +24,11 @@ import zipfile
 import numpy as np
 import tensorflow as tf
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 # Training Parameters
 learning_rate = 0.1
 batch_size = 128

--- a/input_data.py
+++ b/input_data.py
@@ -4,6 +4,10 @@ import gzip
 import os
 import urllib
 import numpy
+try:
+  xrange          # Python 2
+except NameError:
+  xrange = range  # Python 3
 SOURCE_URL = 'http://yann.lecun.com/exdb/mnist/'
 def maybe_download(filename, work_directory):
   """Download the data from Yann's website, unless it's already here."""


### PR DESCRIPTION
__xrange()__ was removed in Python 3 so this change makes the function work identically in both Python 2 and Python 3.