### PR TITLE
Added ReLU activations to multilayer_perceptron.py

### DIFF
--- a/examples/3_NeuralNetworks/multilayer_perceptron.py
+++ b/examples/3_NeuralNetworks/multilayer_perceptron.py
@@ -58,11 +58,11 @@ biases = {
 # Create model
 def multilayer_perceptron(x):
     # Hidden fully connected layer with 256 neurons
-    layer_1 = tf.add(tf.matmul(x, weights['h1']), biases['b1'])
+    layer_1 = tf.maximum(0.,tf.add(tf.matmul(x, weights['h1']), biases['b1']))
     # Hidden fully connected layer with 256 neurons
-    layer_2 = tf.add(tf.matmul(layer_1, weights['h2']), biases['b2'])
+    layer_2 = tf.maximum(0.,tf.add(tf.matmul(layer_1, weights['h2']), biases['b2']))
     # Output fully connected layer with a neuron for each class
-    out_layer = tf.matmul(layer_2, weights['out']) + biases['out']
+    out_layer = tf.maximum(0.,tf.matmul(layer_2, weights['out']) + biases['out'])
     return out_layer
 
 # Construct model


### PR DESCRIPTION
Added missing activation functions to the multilayer.perceptron.py. Chose the ReLU activation. This solves [Issue #209 ](https://github.com/aymericdamien/TensorFlow-Examples/issues/209) Used low-level function (i.e. tf.maximum instead of tf.nn.relu) to keep the low-level style of the existing code.