### PR TITLE
Add activation function

### DIFF
--- a/examples/3_NeuralNetworks/neural_network.py
+++ b/examples/3_NeuralNetworks/neural_network.py
@@ -40,9 +40,9 @@ def neural_net(x_dict):
     # TF Estimator input is a dict, in case of multiple inputs
     x = x_dict['images']
     # Hidden fully connected layer with 256 neurons
-    layer_1 = tf.layers.dense(x, n_hidden_1)
+    layer_1 = tf.nn.relu(tf.layers.dense(x, n_hidden_1))
     # Hidden fully connected layer with 256 neurons
-    layer_2 = tf.layers.dense(layer_1, n_hidden_2)
+    layer_2 = tf.nn.relu(tf.layers.dense(layer_1, n_hidden_2))
     # Output fully connected layer with a neuron for each class
     out_layer = tf.layers.dense(layer_2, num_classes)
     return out_layer

--- a/examples/3_NeuralNetworks/neural_network_raw.py
+++ b/examples/3_NeuralNetworks/neural_network_raw.py
@@ -20,7 +20,7 @@ mnist = input_data.read_data_sets("/tmp/data/", one_hot=True)
 import tensorflow as tf
 
 # Parameters
-learning_rate = 0.1
+learning_rate = 0.01
 num_steps = 500
 batch_size = 128
 display_step = 100
@@ -51,9 +51,9 @@ biases = {
 # Create model
 def neural_net(x):
     # Hidden fully connected layer with 256 neurons
-    layer_1 = tf.add(tf.matmul(x, weights['h1']), biases['b1'])
+    layer_1 = tf.nn.relu(tf.add(tf.matmul(x, weights['h1']), biases['b1']))
     # Hidden fully connected layer with 256 neurons
-    layer_2 = tf.add(tf.matmul(layer_1, weights['h2']), biases['b2'])
+    layer_2 = tf.nn.relu(tf.add(tf.matmul(layer_1, weights['h2']), biases['b2']))
     # Output fully connected layer with a neuron for each class
     out_layer = tf.matmul(layer_2, weights['out']) + biases['out']
     return out_layer


### PR DESCRIPTION
An NN should always have activation functions (like `relu`), or otherwise it's just a trivial linear model.
By applying `relu`, accuracy for `neural_network.py`: 92% -> 95%,
and accuracy for `neural_network_raw.py`: 92% -> 94%
Also the learning rate  is too large, even for an example. In practice it's typical to set it somewhere between 1e-2 and 1e-4.