### PR TITLE
Bug: specify axis=1 when reducing sum

### DIFF
--- a/tensorflow_v2/notebooks/2_BasicModels/logistic_regression.ipynb
+++ b/tensorflow_v2/notebooks/2_BasicModels/logistic_regression.ipynb
@@ -109,7 +109,7 @@
     "    # Clip prediction values to avoid log(0) error.\n",
     "    y_pred = tf.clip_by_value(y_pred, 1e-9, 1.)\n",
     "    # Compute cross-entropy.\n",
-    "    return tf.reduce_mean(-tf.reduce_sum(y_true * tf.math.log(y_pred)))\n",
+    "    return tf.reduce_mean(-tf.reduce_sum(y_true * tf.math.log(y_pred), axis=1))\n",
     "\n",
     "# Accuracy metric.\n",
     "def accuracy(y_pred, y_true):\n",


### PR DESCRIPTION
`tf.reduce_sum()` with `axis=None` returns a scalar, so that the following `tf.reduce_mean()` does nothing but return that same scalar. I seems the intention here was for the sum to be reduced on a per-example basis, before then finding the mean across all examples.