### PR TITLE
bias(error) should not be in linear_regression fn

### DIFF
--- a/tensorflow_v2/notebooks/2_BasicModels/linear_regression.ipynb
+++ b/tensorflow_v2/notebooks/2_BasicModels/linear_regression.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "# Linear regression (Wx + b).\n",
     "def linear_regression(x):\n",
-    "    return W * x + b\n",
+    "    return W * x\n",
     "\n",
     "# Mean square error.\n",
     "def mean_square(y_pred, y_true):\n",


### PR DESCRIPTION
Having  + b in the calculation biases the results.  It give you a regression like y = W*x + W2*b + e where e~N(0,1). You effectively add the error term into the regression. The result looks a bit like having a hidden constant term in the model.  Using regular linear regression, the coefficient estimate (W) is 0.36, and removing +b, you get exactly the same results with this tf version.