### PR TITLE
Fix Python 2 map functions

### DIFF
--- a/tensorflow_v2/notebooks/3_NeuralNetworks/autoencoder.ipynb
+++ b/tensorflow_v2/notebooks/3_NeuralNetworks/autoencoder.ipynb
@@ -178,7 +178,7 @@
     "        loss = mean_square(reconstructed_image, x)\n",
     "\n",
     "    # Variables to update, i.e. trainable variables.\n",
-    "    trainable_variables = weights.values() + biases.values()\n",
+    "    trainable_variables = list(weights.values()) + list(biases.values())\n",
     "    \n",
     "    # Compute gradients.\n",
     "    gradients = g.gradient(loss, trainable_variables)\n",


### PR DESCRIPTION
The funcion `values()` no longer returns a list in Python 3.